### PR TITLE
add pyOpenSSL==16.2.0 to pip install item list inside setup-netbox.yml

### DIFF
--- a/tasks/setup-netbox.yml
+++ b/tasks/setup-netbox.yml
@@ -25,6 +25,7 @@
   with_items:
     - packaging
     - appdirs
+    - pyOpenSSL==16.2.0
   when: (ansible_distribution == "Debian" and ansible_distribution_release == "jessie") or
         (ansible_distribution == "Ubuntu" and ansible_distribution_release == "trusty")
 


### PR DESCRIPTION
when using vagrant to provision and bring up this netbox machine, the process stops on the "perform database migration" TASK, with the following error:

SSL_ST_INIT = _lib.SSL_ST_INIT\nAttributeError: 'module' object has no attribute

adding pyOpenSSL==16.2.0 resolves this issue
