### PR TITLE
Add LDAP Logging to template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,9 @@ netbox_setup_ldap_auth: false
 # http://netbox.readthedocs.io/en/latest/installation/ldap/
 netbox_ldap_config: ""
 
+# LDAP logging
+netbox_setup_ldap_logging: false
+
 # Systemd unit variables (configured by default)
 netbox_setup_systemd: true
 netbox_gunicorn_address: 127.0.0.1

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -32,6 +32,28 @@ REDIS = {
 REMOTE_AUTH_BACKEND = 'netbox.authentication.LDAPBackend'
 {% endif %}
 
+{% if netbox_setup_ldap_logging %}
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'netbox_auth_log': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': '/opt/netbox/django-ldap-debug.log',
+            'maxBytes': 1024 * 500,
+            'backupCount': 5,
+        },
+    },
+    'loggers': {
+        'django_auth_ldap': {
+            'handlers': ['netbox_auth_log'],
+            'level': 'DEBUG',
+        },
+    },
+}
+{% endif %}
+
 {% for setting, value in netbox_config.items() %}
 {% if value in [True, False] %}
 {{ setting }} = {{ 'True' if value else 'False' }}
@@ -41,3 +63,5 @@ REMOTE_AUTH_BACKEND = 'netbox.authentication.LDAPBackend'
 {{ setting }} = json.loads(r"""{{ value | to_json }}""")
 {% endif %}
 {% endfor %}
+
+


### PR DESCRIPTION
Hi there.
Thank you for your ansible role, it works great for me.
Some times I need to debug my LDAP connection and logging is helpful.
To enable logging in Netbox you need to add a few lines in the configuration.py and I added them to the template on my machine.
Do you want to add them to your template? You can enable LDAP logging with the variable `netbox_setup_ldap_logging: true` and it writes the information in `/opt/netbox/django-ldap-debug.log`.